### PR TITLE
Fix apt-get ignoring ppa file

### DIFF
--- a/kicad-ppa/simple-add-ppa.sh
+++ b/kicad-ppa/simple-add-ppa.sh
@@ -4,7 +4,7 @@ set -x
 set -e
 
 REPO="$(echo $1 | sed -e's/ppa://')"
-FILE="$(echo $1 | sed -e's/[^A-Za-z-]/-/g')"
+FILE="$(echo $1 | sed -e's/[^A-Za-z-]/-/g').list"
 KEY=$2
 
 DISTRIB_CODENAME="$(lsb_release -c -s || echo $3)"


### PR DESCRIPTION
Hi,

I discovered an issue when trying out the docker script. I didn't get the latest version of Kicad when using `docker-kicad/kicad-ppa`. Instead I got the version from the ubuntu 14.04 repository.

The failing setup:

```
mithro/kicad        ppa                 a39f1e4e9bd5        3 days ago          1.659 GB
ubuntu              14.04               d0955f21bf24        3 days ago          188.3 MB
ubuntu              14.04.2             d0955f21bf24        3 days ago          188.3 MB
ubuntu              latest              d0955f21bf24        3 days ago          188.3 MB
ubuntu              trusty              d0955f21bf24        3 days ago          188.3 MB
ubuntu              trusty-20150320     d0955f21bf24        3 days ago          188.3 MB

Client version: 1.5.0
Client API version: 1.17
Go version (client): go1.4.1
Git commit (client): a8a31ef
OS/Arch (client): linux/amd64
Server version: 1.5.0
Server API version: 1.17
Go version (server): go1.4.1
Git commit (server): a8a31ef
```

By manually running ´´apt-get update´´ one can see that the `ppa-js-reynaud-ppa-kicad` file is ignored by apt-get:
`N: Ignoring file 'ppa-js-reynaud-ppa-kicad' in directory '/etc/apt/sources.list.d/' as it has no filename extension`

This pull request fixes this issue by adding a .list extension to the apt source file.
